### PR TITLE
STARTING_INVENTORY setting

### DIFF
--- a/PlandoRandomSettings.py
+++ b/PlandoRandomSettings.py
@@ -4,7 +4,7 @@ from SettingsList import logic_tricks, setting_infos, get_settings_from_tab
 from LocationList import location_table
 from StartingItems import inventory, songs, equipment
 
-__version__ = "5-1-73.1.3"
+__version__ = "5-1-73.1.4"
 
 # Parameters for generation
 ALLOW_LOGIC = False # True for random logic, false otherwise
@@ -18,12 +18,8 @@ ALLOW_DERP = False # Randomize pointless things (textshuffle, unclear hints, etc
 # Randomize starting inventory
 # "off": No starting inventory
 # "legacy": Randomly start with Tycoon's Wallet and Fast Travel (Farore's, Prelude, Serenade)
-# "statistical": Randomize starting inventory such that each item, song, or equipment has an independent chance of selection
 # "random": Randomize starting items, songs, and equipment up to the specified maximum
 STARTING_INVENTORY = "random"
-
-# Chance of each item, song, or equipment getting selected for the "statistical" STARTING_INVENTORY setting
-STARTING_INVENTORY_SELECTION_CHANCE = 0.05 # Between 0 and 1
 
 # Maximum number of starting items, songs, and equipment for the "random" STARTING_INVENTORY setting
 MAX_STARTING_ITEMS = 4 # Between 0 and 32
@@ -76,16 +72,6 @@ def populate_location_exclusions():
     return excluded_locations
 
 
-# Populate starting pool such that each item, song, or equipment has an independent chance of selection
-def populate_statistical_starting_pool(pool):
-    starting_pool = []
-    for item in pool:
-        if random.random() < STARTING_INVENTORY_SELECTION_CHANCE:
-            starting_pool.append(item)
-
-    return starting_pool
-
-
 # Randomize starting pool up to the specified maximum
 def populate_random_starting_pool(pool, max):
     k = random.randint(0, max)
@@ -103,8 +89,6 @@ def populate_starting_items():
             starting_items.append("wallet2")
             starting_items.append("wallet3")
         return starting_items
-    elif STARTING_INVENTORY == "statistical":
-        return populate_statistical_starting_pool(inventory)
     elif STARTING_INVENTORY == "random":
         return populate_random_starting_pool(inventory, MAX_STARTING_ITEMS)
     else:
@@ -119,8 +103,6 @@ def populate_starting_songs():
             starting_songs.append("prelude")
             starting_songs.append("serenade")
         return starting_songs
-    elif STARTING_INVENTORY == "statistical":
-        return populate_statistical_starting_pool(songs)
     elif STARTING_INVENTORY == "random":
         return populate_random_starting_pool(songs, MAX_STARTING_SONGS)
     else:
@@ -131,8 +113,6 @@ def populate_starting_songs():
 def populate_starting_equipment():
     if STARTING_INVENTORY == "legacy":
         return []
-    elif STARTING_INVENTORY == "statistical":
-        return populate_statistical_starting_pool(equipment)
     elif STARTING_INVENTORY == "random":
         return populate_random_starting_pool(equipment, MAX_STARTING_EQUIPMENT)
     else:

--- a/PlandoRandomSettings.py
+++ b/PlandoRandomSettings.py
@@ -73,7 +73,7 @@ def populate_location_exclusions():
 
 
 # Randomize starting pool up to the specified maximum
-def populate_random_starting_pool(pool, max):
+def populate_starting_pool(pool, max):
     k = random.randint(0, max)
     return random.sample(list(pool), k)
 
@@ -90,7 +90,7 @@ def populate_starting_items():
             starting_items.append("wallet3")
         return starting_items
     elif STARTING_INVENTORY == "random":
-        return populate_random_starting_pool(inventory, MAX_STARTING_ITEMS)
+        return populate_starting_pool(inventory, MAX_STARTING_ITEMS)
     else:
         return []
 
@@ -104,7 +104,7 @@ def populate_starting_songs():
             starting_songs.append("serenade")
         return starting_songs
     elif STARTING_INVENTORY == "random":
-        return populate_random_starting_pool(songs, MAX_STARTING_SONGS)
+        return populate_starting_pool(songs, MAX_STARTING_SONGS)
     else:
         return []
 
@@ -114,7 +114,7 @@ def populate_starting_equipment():
     if STARTING_INVENTORY == "legacy":
         return []
     elif STARTING_INVENTORY == "random":
-        return populate_random_starting_pool(equipment, MAX_STARTING_EQUIPMENT)
+        return populate_starting_pool(equipment, MAX_STARTING_EQUIPMENT)
     else:
         return []
 

--- a/PlandoRandomSettings.py
+++ b/PlandoRandomSettings.py
@@ -72,6 +72,22 @@ def populate_location_exclusions():
     return excluded_locations
 
 
+# Whether to start with Fast Travel
+def start_with_fast_travel():
+    if not hasattr(start_with_fast_travel, "choice"):
+        start_with_fast_travel.choice = random.choice([True, False])
+
+    return start_with_fast_travel.choice
+
+
+# Whether to start with Tycoon's Wallet
+def start_with_tycoons_wallet():
+    if not hasattr(start_with_tycoons_wallet, "choice"):
+        start_with_tycoons_wallet.choice = random.choice([True, False])
+
+    return start_with_tycoons_wallet.choice
+
+
 # Randomize starting pool up to the specified maximum
 def populate_starting_pool(pool, max):
     k = random.randint(0, max)
@@ -82,9 +98,9 @@ def populate_starting_pool(pool, max):
 def populate_starting_items():
     if STARTING_INVENTORY == "legacy":
         starting_items = []
-        if fast_travel:
+        if start_with_fast_travel():
             starting_items.append("farores_wind")
-        if omega_wallet:
+        if start_with_tycoons_wallet():
             starting_items.append("wallet")
             starting_items.append("wallet2")
             starting_items.append("wallet3")
@@ -99,7 +115,7 @@ def populate_starting_items():
 def populate_starting_songs():
     if STARTING_INVENTORY == "legacy":
         starting_songs = []
-        if fast_travel:
+        if start_with_fast_travel():
             starting_songs.append("prelude")
             starting_songs.append("serenade")
         return starting_songs
@@ -179,11 +195,6 @@ if STARTING_INVENTORY == "off":
     settings_to_randomize.pop(settings_to_randomize.index('starting_equipment'))
     settings_to_randomize.pop(settings_to_randomize.index('starting_items'))
     settings_to_randomize.pop(settings_to_randomize.index('starting_songs'))
-
-# Randomize the starting items and songs in legacy mode
-if STARTING_INVENTORY == "legacy":
-    fast_travel = random.choice([True, False])
-    omega_wallet = random.choice([True, False])
 
 # Draw the randomized settings
 random_settings = {}

--- a/PlandoRandomSettings.py
+++ b/PlandoRandomSettings.py
@@ -18,7 +18,7 @@ ALLOW_DERP = False # Randomize pointless things (textshuffle, unclear hints, etc
 # Randomize starting inventory
 # "off": No starting inventory
 # "legacy": Randomly start with Tycoon's Wallet and Fast Travel (Farore's, Prelude, Serenade)
-# "random": Randomize starting items, songs, and equipment up to the specified maximum
+# "random": Randomize starting items, songs, and equipment up to the specified maximum for each category
 STARTING_INVENTORY = "random"
 
 # Maximum number of starting items, songs, and equipment for the "random" STARTING_INVENTORY setting


### PR DESCRIPTION
- Establish STARTING_INVENTORY setting with "random" value that randomizes starting items, songs, and equipment up to the specified maximum for each category. This is renamed from STARTING_ITEMS to match the name in the settings list and distinguish between the item, song, and equipment categories.
- Allow specification of a different maximum number for items, songs, and equipment. This allows setting any maximum to 0 to avoid randomizing that category.
- Refactor "legacy" code path to move all STARTING_INVENTORY value checks into the populate functions.