### PR TITLE
Set skip_child_zelda to false for multiworld

### DIFF
--- a/PlandoRandomSettings.py
+++ b/PlandoRandomSettings.py
@@ -166,8 +166,7 @@ def main():
     # Draw the random settings
     random_settings = {}
     for setting, options in weight_dict.items():
-        if isinstance(options, dict): # Skip settings that are hardcoded lists, like starting_items
-            random_settings[setting] = random.choices(list(options.keys()), weights=list(options.values()))[0]
+        random_settings[setting] = random.choices(list(options.keys()), weights=list(options.values()))[0]
 
 
     # Check conditional settings for rrl

--- a/PlandoRandomSettings.py
+++ b/PlandoRandomSettings.py
@@ -166,7 +166,8 @@ def main():
     # Draw the random settings
     random_settings = {}
     for setting, options in weight_dict.items():
-        random_settings[setting] = random.choices(list(options.keys()), weights=list(options.values()))[0]
+        if isinstance(options, dict): # Skip settings that are hardcoded lists, like starting_items
+            random_settings[setting] = random.choices(list(options.keys()), weights=list(options.values()))[0]
 
 
     # Check conditional settings for rrl

--- a/weights/rsl_multiworld.json
+++ b/weights/rsl_multiworld.json
@@ -2,7 +2,7 @@
     "open_door_of_time": {
         "true": 100,
         "false": 0
-    }, 
+    },
     "zora_fountain": {
         "closed": 0,
         "adult": 0,
@@ -44,5 +44,26 @@
     },
     "starting_songs": [
         "suns_song"
-    ]
+    ],
+    "item_pool_value": {
+        "plentiful": 20,
+        "balanced": 40,
+        "scarce": 20,
+        "minimal": 20
+    },
+    "triforce_hunt": {
+        "true": 14.28,
+        "false": 85.72
+    },
+    "junk_ice_traps": {
+        "off": 30,
+        "normal": 30,
+        "on": 15,
+        "mayhem": 15,
+        "onslaught": 10
+    },
+    "skip_child_zelda": {
+        "true": 0,
+        "false": 100
+    }
 }

--- a/weights/rsl_multiworld.json
+++ b/weights/rsl_multiworld.json
@@ -45,31 +45,6 @@
     "starting_songs": [
         "suns_song"
     ],
-    "item_pool_value": {
-        "plentiful": 20,
-        "balanced": 40,
-        "scarce": 20,
-        "minimal": 20
-    },
-    "triforce_hunt": {
-        "true": 14.28,
-        "false": 85.72
-    },
-    "junk_ice_traps": {
-        "off": 30,
-        "normal": 30,
-        "on": 15,
-        "mayhem": 15,
-        "onslaught": 10
-    },
-    "shuffle_smallkeys": {
-        "remove": 16.66,
-        "vanilla": 16.66,
-        "dungeon": 16.66,
-        "overworld": 16.66,
-        "any_dungeon": 16.66,
-        "keysanity": 16.66
-    },
     "skip_child_zelda": {
         "true": 0,
         "false": 100

--- a/weights/rsl_multiworld.json
+++ b/weights/rsl_multiworld.json
@@ -62,6 +62,14 @@
         "mayhem": 15,
         "onslaught": 10
     },
+    "shuffle_smallkeys": {
+        "remove": 16.66,
+        "vanilla": 16.66,
+        "dungeon": 16.66,
+        "overworld": 16.66,
+        "any_dungeon": 16.66,
+        "keysanity": 16.66
+    },
     "skip_child_zelda": {
         "true": 0,
         "false": 100


### PR DESCRIPTION
- Set skip_child_zelda to false to avoid multiworld bug that hasn't been fixed yet.
- When drawing random settings, skip settings that are hardcoded lists, like starting_items
- There are several settings expected when RRL_CONDITIONALS = True (item_pool_value, triforce_hunt, junk_ice_traps, shuffle_smallkeys). Added these so that these conditionals can be used with MW.