### PR TITLE
Update to version 6 of the randomizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This script will generate a plando json file that can be fed into the Ocarina of
 This script allows us to blindly randomize anything and (nearly) everything in the ranomizer, rather than just the natively supported random settings.
 
 ## Instructions
-1. Download the dev-R branch of Ocarina of Time Randomizer. Version v5.2.65 R-11 or newer  (https://github.com/Roman971/OoT-Randomizer).
+1. Download the dev-R branch of Ocarina of Time Randomizer. Version v6.0.2 R-3 or newer  (https://github.com/Roman971/OoT-Randomizer).
 2. Navigate to the folder that contains `Gui.py` and make a new folder named `plando-random-settings`.
 3. Place the contents of this repository in this new folder.
 4. Run `PlandoRandomSettings.py` by either double clicking via the command line `$ python3 PlandoRandomSettings.py` to generate `blind_random_settings.json`.

--- a/rsl_version.py
+++ b/rsl_version.py
@@ -1,4 +1,4 @@
-__version__ = "5.2.119 R-1 v1"
+__version__ = "6.0.2 R-3 v1"
 version_hash_1 = "Longshot"
 version_hash_2 = "Longshot"
 


### PR DESCRIPTION
Despite not being locked to a specific version of Dev-R, the latest release of this script still can't be used with version 6.0 of the randomizer because of how the version check works. This updates the version to fix that.

**TODO:** New icon hash prefix?