### PR TITLE
Update beginner weights, add intermediate weights

### DIFF
--- a/weights/beginner_override.json
+++ b/weights/beginner_override.json
@@ -4,27 +4,7 @@
         "lacs_tokens_max": 50,
         "extra_conditionals": {
             "restrict_one_entrance_randomizer": true
-        },
-        "tricks": [
-            "logic_fewer_tunic_requirements",
-            "logic_grottos_without_agony",
-            "logic_child_deadhand",
-            "logic_man_on_roof",
-            "logic_dc_jump",
-            "logic_rusted_switches",
-            "logic_windmill_poh",
-            "logic_crater_bean_poh_with_hovers",
-            "logic_forest_vines",
-            "logic_goron_city_pot_with_strength",
-            "logic_lens_botw",
-            "logic_lens_castle",
-            "logic_lens_gtg",
-            "logic_lens_shadow",
-            "logic_lens_shadow_back",
-            "logic_lens_spirit",
-            "logic_visible_collisions",
-            "logic_deku_b1_webs_with_bow"
-        ]
+        }
     },
     "weights": {
         "trials_random": {

--- a/weights/intermediate_override.json
+++ b/weights/intermediate_override.json
@@ -1,10 +1,7 @@
 {
     "options": {
-        "bridge_tokens_max": 50,
-        "lacs_tokens_max": 50,
-        "extra_conditionals": {
-            "restrict_one_entrance_randomizer": true
-        },
+        "bridge_tokens_max": 75,
+        "lacs_tokens_max": 75,
         "tricks": [
             "logic_fewer_tunic_requirements",
             "logic_grottos_without_agony",
@@ -32,7 +29,9 @@
         },
         "trials": {
             "0": 1,
-            "1": 1
+            "1": 1,
+            "2": 1,
+            "3": 1
         },
         "shuffle_overworld_entrances": {
             "false": 1
@@ -41,24 +40,8 @@
             "false": 1
         },
         "mq_dungeons": {
-            "0": 1
-        },
-        "shuffle_song_items": {
-            "song": 5,
-            "any": 3
-        },
-        "shuffle_scrubs": {
-            "off": 8,
-            "low": 5
-        },
-        "no_escape_sequence": {
-            "true": 1
-        },
-        "no_epona_race": {
-            "true": 1
-        },
-        "skip_some_minigame_phases": {
-            "true": 1
+            "0": 1,
+            "1": 1
         },
         "big_poe_count_random": {
             "false": 1
@@ -67,42 +50,29 @@
             "1": 1,
             "2": 1,
             "3": 1,
-            "4": 1
+            "4": 1,
+            "5": 1,
+            "6": 1,
+            "7": 1
         },
         "hints": {
-            "always": 1
-        },
-        "hint_dist": {
-            "balanced": 4,
-            "scrubs": 1,
-            "strong": 4,
-            "tournament": 1,
-            "tournament_s3": 1,
-            "very_strong": 4
+            "always": 7,
+            "agony": 1
         },
         "text_shuffle": {
             "none": 1
         },
         "damage_multiplier": {
             "half": 3,
-            "normal": 13,
-            "double": 4
+            "normal": 11,
+            "double": 4,
+            "quadruple": 2
         },
         "no_collectible_hearts": {
             "false": 1
         },
-        "item_pool_value": {
-            "plentiful": 3,
-            "balanced": 11,
-            "scarce": 5
-        },
-        "junk_ice_traps": {
-            "off": 6,
-            "normal": 6,
-            "on": 3
-        },
         "logic_earliest_adult_trade": {
-            "poachers_saw": 1
+            "cojiro": 1
         }
     }
 }


### PR DESCRIPTION
This changes Beginner weights to match the proposal at <https://ootr.fenhl.net/static/rsl-beginner-weights.html> and adds the Intermedate weights listed there. Sending this PR to your partialrefactor branch so it can be merged immediately.