### PR TITLE
Remove multiworld Skip Child Zelda override

### DIFF
--- a/weights/multiworld_override.json
+++ b/weights/multiworld_override.json
@@ -45,10 +45,6 @@
         },
         "starting_songs": [
             "suns_song"
-        ],
-        "skip_child_zelda": {
-            "true": 0,
-            "false": 100
-        }
+        ]
     }
 }


### PR DESCRIPTION
This was a workaround for a bug that has been fixed in https://github.com/Roman971/OoT-Randomizer/commit/861c80eba3f2427dd8706022c1c3cf056fdea10f.