### PR TITLE
Forbid custom LACS condition and Triforce Hunt

### DIFF
--- a/conditionals.py
+++ b/conditionals.py
@@ -39,7 +39,7 @@ def disable_lacs_condition_ifnot_ganonbosskey(_, random_settings):
     avoid requiring constant trips every couple skulltula tokens, we are disabling this
     setting if the ganon boss key is not there (if its there the condition is listed on the
     Temple of Time pedestal """
-    if random_settings['shuffle_ganon_bosskey'] != 'on_lacs':
+    if random_settings['shuffle_ganon_bosskey'] != 'on_lacs' or random_settings['triforce_hunt'] == 'true':
         random_settings['lacs_condition'] = 'lacs_vanilla'
 
 


### PR DESCRIPTION
Custom LACS conditions are forbidden if Ganon's boss key is not on LACS to allow for LACS conditions to be hinted on the Temple of Time pedestal. If Triforce Hunt is on, the randomizer ignores the `shuffle_ganon_bosskey` setting and places the key on collecting all Triforce pieces. The random settings script did not check if Triforce Hunt was moving the key off of LACS despite `shuffle_ganon_bosskey` being set to LACS. This PR adds the check to the existing conditional function.