### PR TITLE
Allow concurrent runs

### DIFF
--- a/RandomSettingsGenerator.py
+++ b/RandomSettingsGenerator.py
@@ -93,10 +93,10 @@ def main():
             if completed_process.returncode == 0:
                 break
             if i == max_retries-1 and completed_process.returncode != 0:
-                raise tools.RandomizerError(completed_process.stderr.decode("utf-8"))
+                raise tools.RandomizerError(completed_process.stderr)
 
     if not no_seed:
-        print(completed_process.stderr.decode("utf-8").split("Patching ROM.")[-1])
+        print(completed_process.stderr.split("Patching ROM.")[-1])
 
     for plando_filename in plandos_to_cleanup:
         cleanup(os.path.join('data', plando_filename))

--- a/roll_settings.py
+++ b/roll_settings.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import datetime
 import json
 import random
 import conditionals as conds
@@ -175,7 +176,11 @@ def generate_plando(weights, override_weights_fname):
         "file_hash": [version_hash_1, version_hash_2, *random.choices(HASH_ICONS, k=3)]
     }
 
+    plando_filename = f'random_settings_{datetime.datetime.utcnow():%Y-%m-%d_%H-%M-%S}.json'
+
     if not os.path.isdir("data"):
         os.mkdir("data")
-    with open(os.path.join("data", "random_settings.json"), 'w') as fp:
+    with open(os.path.join("data", plando_filename), 'w') as fp:
         json.dump(output, fp, indent=4)
+
+    return plando_filename

--- a/roll_settings.py
+++ b/roll_settings.py
@@ -176,7 +176,7 @@ def generate_plando(weights, override_weights_fname):
         "file_hash": [version_hash_1, version_hash_2, *random.choices(HASH_ICONS, k=3)]
     }
 
-    plando_filename = f'random_settings_{datetime.datetime.utcnow():%Y-%m-%d_%H-%M-%S}.json'
+    plando_filename = f'random_settings_{datetime.datetime.utcnow():%Y-%m-%d_%H-%M-%S_%f}.json'
 
     if not os.path.isdir("data"):
         os.mkdir("data")

--- a/rsl_tools.py
+++ b/rsl_tools.py
@@ -80,6 +80,7 @@ def generate_patch_file(plando_filename='random_settings.json', worldcount=1, ma
             [sys.executable, os.path.join("randomizer", "OoTRandomizer.py"), "--settings=-"],
             capture_output=True,
             input=settings,
+            encoding='utf-8',
         )
 
         if completed_process.returncode != 0:

--- a/rsl_tools.py
+++ b/rsl_tools.py
@@ -51,32 +51,36 @@ def check_version():
         download_randomizer()
     return
 
-
 # This function will take things from the GUI eventually.
-def init_randomizer_settings(worldcount=1):
-    rootdir = os.getcwd()
-
-    randomizer_settings = {
+def randomizer_settings(rootdir=os.getcwd(), plando_filename='random_settings.json', worldcount=1):
+    return {
         "rom": find_rom_file(),
         "output_dir": os.path.join(rootdir, 'patches'),
-        "compress_rom": "Patch", 
+        "compress_rom": "Patch",
         "enable_distribution_file": "True",
-        "distribution_file": os.path.join(rootdir, "data", "random_settings.json"),
+        "distribution_file": os.path.join(rootdir, "data", plando_filename),
         "create_spoiler": "True",
         "world_count": worldcount
     }
 
+def init_randomizer_settings(plando_filename='random_settings.json', worldcount=1):
+    settings = randomizer_settings(plando_filename=plando_filename, worldcount=worldcount)
+
     with open(os.path.join('data', 'randomizer_settings.json'), 'w') as fp:
-        json.dump(randomizer_settings, fp, indent=4)
+        json.dump(settings, fp, indent=4)
 
 
-def generate_patch_file(max_retries=3):
+def generate_patch_file(plando_filename='random_settings.json', worldcount=1, max_retries=3):
+    settings = json.dumps(randomizer_settings(plando_filename=plando_filename, worldcount=worldcount))
+
     retries = 0
     while(True):
         print(f"RSL GENERATOR: RUNNING THE RANDOMIZER - ATTEMPT {retries+1} OF {max_retries}")
         completed_process = subprocess.run(
-            [sys.executable, os.path.join("randomizer", "OoTRandomizer.py"), "--settings", os.path.join("..", "data", "randomizer_settings.json")],
-            capture_output=True)
+            [sys.executable, os.path.join("randomizer", "OoTRandomizer.py"), "--settings=-"],
+            capture_output=True,
+            input=settings,
+        )
 
         if completed_process.returncode != 0:
             retries += 1


### PR DESCRIPTION
This implements #24 using the following changes:

* The filename for the generated plando now includes a timestamp, allowing multiple instances of the randomizer to be called without interfering with each other.
* The randomizer settings are passed directly to the randomizer via stdin instead of being saved to disk (unless `--no_seed` is passed).
* The plando file is now deleted at the end of a successful run rather than the start of the next run (unless `--no_seed` is passed, in which case it's not deleted at all since it's essentially the script's output).
* A command-line flag `--no_log_errors` is added which suppresses both the creation of `ERRORLOG.TXT` (but errors are still written to stdout) and the deletion of this file from previous instances (which could otherwise cause crashes with concurrent runs on Windows).