### PR TITLE
Set minimum Triforce goal to 2

### DIFF
--- a/roll_settings.py
+++ b/roll_settings.py
@@ -132,11 +132,9 @@ def generate_plando(weights, override_weights_fname):
     ####################################################################################
     # Generate even weights for tokens and triforce pieces given the max value (Maybe put this into the step that loads the weights)
     for nset in ["bridge_tokens", "lacs_tokens", "triforce_goal_per_world"]:
-        kw = nset + "_max"
-        nmax = weight_options[kw] if kw in weight_options else 100
-        weight_dict[nset] = {i+1: 100./nmax for i in range(nmax)}
-        if kw in weight_dict:
-            weight_dict.pop(kw)
+        nmin = weight_options.get(nset + "_min", 1)
+        nmax = weight_options.get(nset + "_max", 100)
+        weight_dict[nset] = {i: 1 for i in range(nmin, nmax + 1)}
     ####################################################################################
 
     # Draw the random settings

--- a/weights/rsl_season3.json
+++ b/weights/rsl_season3.json
@@ -2,6 +2,7 @@
     "options": {
         "bridge_tokens_max": 100,
         "lacs_tokens_max": 100,
+        "triforce_goal_per_world_min": 2,
         "triforce_goal_per_world_max": 100,
         "starting_items": true,
         "conditionals": {


### PR DESCRIPTION
This is a workaround for [TestRunnerSRL/OoT-Randomizer#1331](https://github.com/TestRunnerSRL/OoT-Randomizer/issues/1331). It adds an option to specify the minimum number of Triforce pieces required via `triforce_goal_per_world_min` (same for `bridge_tokens_min` and `lacs_tokens_min`) and uses that feature to set the minimum Triforce goal in S3 to 2.