### PR TITLE
Set minimum Triforce goal to 2 if SCZ and Songsanity are on

### DIFF
--- a/conditionals.py
+++ b/conditionals.py
@@ -63,3 +63,10 @@ def restrict_one_entrance_randomizer(_, random_settings):
         setting, off_option = item.split(":")
         if setting != keepon:
             random_settings[setting] = off_option
+
+def workaround_th_scz_bug(weight_dict, random_settings):
+    """ Makes sure https://github.com/TestRunnerSRL/OoT-Randomizer/issues/1331 won't happen. """
+    weights = weight_dict['triforce_goal_per_world']
+    if random_settings['triforce_hunt'] and random_settings['triforce_goal_per_world'] == 1 and random_settings['shuffle_song_items'] == 'any' and random_settings['skip_child_zelda']:
+        weights.pop(1)
+        random_settings['triforce_goal_per_world'] = random.choices(list(weights.keys()), weights=list(weights.values()))[0]

--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 version_hash_1 = "Cucco"
 version_hash_2 = "Cucco"
 

--- a/weights/rsl_season3.json
+++ b/weights/rsl_season3.json
@@ -9,7 +9,8 @@
             "exclude_ice_trap_misery": true,
             "disable_fortresskeys_independence": true,
             "disable_lacs_condition_ifnot_ganonbosskey": true,
-            "restrict_one_entrance_randomizer": false
+            "restrict_one_entrance_randomizer": false,
+            "workaround_th_scz_bug": true
         },
         "tricks": [
             "logic_fewer_tunic_requirements",


### PR DESCRIPTION
An improved implementation of #27 that only applies if Skip Child Zelda is on and songs are shuffled anywhere.