### PR TITLE
Fix permissions in randomizer repo after downloading

### DIFF
--- a/rsl_tools.py
+++ b/rsl_tools.py
@@ -5,6 +5,7 @@ import shutil
 import os
 import json
 import glob
+import stat
 from version import randomizer_commit, randomizer_version
 try: 
     import requests
@@ -33,6 +34,10 @@ def download_randomizer():
     os.rename(f'OoT-Randomizer-{randomizer_commit}', 'randomizer')
     with open(os.path.join('randomizer', '__init__.py'), 'w') as fp:
         pass
+
+    # Restore permissions in the unzipped randomizer
+    for executable in [os.path.join('randomizer', 'OoTRandomizer.py'), os.path.join('randomizer', 'Decompress', 'Decompress')]:
+        os.chmod(executable, os.stat(executable).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     # Delete the zip file
     os.remove(zippath)


### PR DESCRIPTION
This adds a step to the randomizer download function that makes the following files executable:

* `randomizer/Decompress/Decompress` to fix #29
* `randomizer/OoTRandomizer.py` for convenience in case the randomizer is called directly from elsewhere (RSLBot may need this in the future)

This works cross-platform because the [`os.chmod`](https://docs.python.org/3/library/os.html#os.chmod) calls are simply ignored on Windows.