### PR TITLE
Make Decompress.out executable and update paths for rando changes

### DIFF
--- a/rsl_tools.py
+++ b/rsl_tools.py
@@ -39,7 +39,7 @@ def download_randomizer():
         pass
 
     # Restore permissions in the unzipped randomizer
-    for executable in [os.path.join('randomizer', 'OoTRandomizer.py'), os.path.join('randomizer', 'Decompress', 'Decompress'), os.path.join('randomizer', 'Decompress', 'Decompress.out')]:
+    for executable in [os.path.join('randomizer', 'OoTRandomizer.py'), os.path.join('randomizer', 'bin', 'Decompress', 'Decompress'), os.path.join('randomizer', 'bin', 'Decompress', 'Decompress.out')]:
         os.chmod(executable, os.stat(executable).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     # Delete the zip file

--- a/rsl_tools.py
+++ b/rsl_tools.py
@@ -39,7 +39,7 @@ def download_randomizer():
         pass
 
     # Restore permissions in the unzipped randomizer
-    for executable in [os.path.join('randomizer', 'OoTRandomizer.py'), os.path.join('randomizer', 'Decompress', 'Decompress')]:
+    for executable in [os.path.join('randomizer', 'OoTRandomizer.py'), os.path.join('randomizer', 'Decompress', 'Decompress'), os.path.join('randomizer', 'Decompress', 'Decompress.out')]:
         os.chmod(executable, os.stat(executable).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     # Delete the zip file


### PR DESCRIPTION
This should fix the script on macOS, which had an issue similar to #29, and on current randomizer versions with TestRunnerSRL/OoT-Randomizer#1487.