### PR TITLE
Remove workaround for TH/SCZ bug

### DIFF
--- a/conditionals.py
+++ b/conditionals.py
@@ -54,10 +54,3 @@ def restrict_one_entrance_randomizer(_, random_settings):
         setting, off_option = item.split(":")
         if setting != keepon:
             random_settings[setting] = off_option
-
-def workaround_th_scz_bug(weight_dict, random_settings):
-    """ Makes sure https://github.com/TestRunnerSRL/OoT-Randomizer/issues/1331 won't happen. """
-    weights = weight_dict['triforce_goal_per_world']
-    if random_settings['triforce_hunt'] and random_settings['triforce_goal_per_world'] == 1 and random_settings['shuffle_song_items'] == 'any' and random_settings['skip_child_zelda']:
-        weights.pop(1)
-        random_settings['triforce_goal_per_world'] = random.choices(list(weights.keys()), weights=list(weights.values()))[0]

--- a/weights/rsl_season3.json
+++ b/weights/rsl_season3.json
@@ -8,8 +8,7 @@
             "exclude_minimal_triforce_hunt": true,
             "exclude_ice_trap_misery": true,
             "disable_hideoutkeys_independence": true,
-            "restrict_one_entrance_randomizer": false,
-            "workaround_th_scz_bug": true
+            "restrict_one_entrance_randomizer": false
         },
         "tricks": [
             "logic_fewer_tunic_requirements",


### PR DESCRIPTION
This reverts #28, which was a workaround for TestRunnerSRL/OoT-Randomizer#1331. That bug was fixed in TestRunnerSRL/OoT-Randomizer#1343, i.e. version 6.0.73 of the randomizer. Since this script uses version 6.0.108 R-1 now, the workaround is no longer needed.