### PR TITLE
Update Beginner and Intermediate weights for S4

### DIFF
--- a/weights/beginner_override.json
+++ b/weights/beginner_override.json
@@ -24,20 +24,17 @@
             "0": 1
         },
         "shuffle_song_items": {
-            "song": 5,
-            "any": 3
+            "song": 6,
+            "any": 4
         },
         "shuffle_scrubs": {
-            "off": 8,
+            "off": 10,
             "low": 5
         },
         "no_escape_sequence": {
             "true": 1
         },
         "no_epona_race": {
-            "true": 1
-        },
-        "skip_some_minigame_phases": {
             "true": 1
         },
         "big_poe_count_random": {
@@ -53,12 +50,10 @@
             "always": 1
         },
         "hint_dist": {
-            "balanced": 4,
+            "balanced": 1,
             "scrubs": 1,
-            "strong": 4,
-            "tournament": 1,
-            "tournament_s3": 1,
-            "very_strong": 4
+            "strong": 1,
+            "very_strong": 1
         },
         "text_shuffle": {
             "none": 1
@@ -68,16 +63,13 @@
             "normal": 13,
             "double": 4
         },
-        "no_collectible_hearts": {
-            "false": 1
-        },
         "item_pool_value": {
             "plentiful": 3,
-            "balanced": 11,
+            "balanced": 12,
             "scarce": 5
         },
         "junk_ice_traps": {
-            "off": 6,
+            "off": 12,
             "normal": 6,
             "on": 3
         },

--- a/weights/intermediate_override.json
+++ b/weights/intermediate_override.json
@@ -43,7 +43,7 @@
             "7": 1
         },
         "hints": {
-            "always": 7,
+            "always": 19,
             "agony": 1
         },
         "text_shuffle": {
@@ -54,9 +54,6 @@
             "normal": 11,
             "double": 4,
             "quadruple": 2
-        },
-        "no_collectible_hearts": {
-            "false": 1
         },
         "logic_earliest_adult_trade": {
             "cojiro": 1


### PR DESCRIPTION
Some of these weights are based on the League weights, so where those were changed, this PR changes Beginner/Intermediate accordingly. For example, League changed `item_pool_value` from 3/8/5/3 to 3/9/5/3, and Beginner is supposed to be that but with Minimal replaced with Balanced, so it's changed from 3/11/5/0 to 3/12/5/0.