### PR TITLE
Disable randomized setting overrides

### DIFF
--- a/conditionals.py
+++ b/conditionals.py
@@ -101,3 +101,9 @@ def shuffle_goal_hints(random_settings, **kwargs):
     distroin['distribution']['woth'] = distroin['distribution']['goal']
     distroin['distribution']['goal'] = woth
     random_settings['hint_dist_user'] = distroin
+
+def disable_randomized_setting_override(random_settings, **kwargs):
+    """ Removes mq_dungeons if mq_dungeons_random is on, since mq_dungeons_random would otherwise be ignored. Same with other “_random” settings """
+    for setting_name in list(random_settings): # copy the list of setting names to avoid modifying the dict during iteration
+        if random_settings.get(f'{setting_name}_random'):
+            del random_settings[setting_name]

--- a/weights/rsl_season4.json
+++ b/weights/rsl_season4.json
@@ -11,7 +11,8 @@
             "restrict_one_entrance_randomizer": [false],
             "random_scrubs_start_wallet": [true],
             "dynamic_skulltula_wincon": [true, 15, "40/40/20"],
-            "shuffle_goal_hints": [true, 50]
+            "shuffle_goal_hints": [true, 50],
+            "disable_randomized_setting_override": [true]
         },
         "tricks": [
             "logic_fewer_tunic_requirements",


### PR DESCRIPTION
TestRunnerSRL/OoT-Randomizer#1333 changed the way plandos that specify both the `mq_dungeons_random` setting and the `mq_dungeons` setting behave: Rather than ignoring `mq_dungeons`, `mq_dungeons_random` is now ignored (except the MQ info is still displayed on maps and in the pause menu for 0 or 12 MQ). This PR adds an override to omit `mq_dungeons` from the plando if `mq_dungeons_random` is on to restore the old behavior. This is also done for `chicken_count` and `big_poe_count` but that doesn't change the effective weights.