### PR TITLE
Enable 0 trials hint for Beginner and Intermediate weights

### DIFF
--- a/weights/beginner_override.json
+++ b/weights/beginner_override.json
@@ -4,11 +4,12 @@
         "ganon_bosskey_tokens_max": 50,
         "extra_conditionals": {
             "restrict_one_entrance_randomizer": [true]
-        }
+        },
+        "allow_random_and_plando": true
     },
     "weights": {
         "trials_random": {
-            "false": 1
+            "true": 1
         },
         "trials": {
             "0": 1,

--- a/weights/intermediate_override.json
+++ b/weights/intermediate_override.json
@@ -8,11 +8,12 @@
             "logic_lens_shadow_mq",
             "logic_lens_shadow_mq_back",
             "logic_lens_spirit_mq"
-        ]
+        ],
+        "allow_random_and_plando": true
     },
     "weights": {
         "trials_random": {
-            "false": 1
+            "true": 1
         },
         "trials": {
             "0": 1,


### PR DESCRIPTION
The Beginner and Intermediate presets use the `trials` setting to limit the number of trials that can be active. Currently, this results in a quirk where if 0 trials are rolled, no “Sheik dispelled the barrier” hint is generated. That's something you have to learn for these weights and then unlearn again once you move on to the full League weights.

This PR uses the `allow_random_and_plando` option to always enable `trials_random` setting in these weights, thus forcing trials hints to generate even for 0 trials, while keeping the actual trials weights the same. This doesn't break anything because these overrides don't use any `_random` settings for actual weight changes.