### PR TITLE
Update script for latest dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,11 @@ randomizer.zip
 random_settings.json
 patches/
 data/
-
+failed_settings/
 
 
 
 blind_random_settings.json
 my_weights.json
 ERRORLOG.TXT
+weights_report.html

--- a/RandomSettingsGenerator.py
+++ b/RandomSettingsGenerator.py
@@ -89,7 +89,7 @@ def main():
 
     # If we only want to check for new/changed settings
     if check_new_settings:
-        _, rslweights = rs.load_weights_file("rsl_season4.json")
+        _, _, rslweights = rs.load_weights_file("rsl_season4.json")
         tools.check_for_setting_changes(rslweights, rs.generate_balanced_weights(None))
         return
 

--- a/rsl_tools.py
+++ b/rsl_tools.py
@@ -14,6 +14,8 @@ try:
 except ModuleNotFoundError:
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'requests'])
     import requests
+sys.path.append("randomizer")
+from randomizer.SettingsList import get_setting_info
 
 
 
@@ -39,7 +41,7 @@ def download_randomizer():
         pass
 
     # Restore permissions in the unzipped randomizer
-    for executable in [os.path.join('randomizer', 'OoTRandomizer.py'), os.path.join('randomizer', 'Decompress', 'Decompress')]:
+    for executable in [os.path.join('randomizer', 'OoTRandomizer.py'), os.path.join('randomizer', 'bin', 'Decompress', 'Decompress')]:
         os.chmod(executable, os.stat(executable).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     # Delete the zip file
@@ -121,7 +123,7 @@ def find_rom_file():
 # Compare weights file to settings list to check for changes to the randomizer settings table
 def check_for_setting_changes(weights, randomizer_settings):
     """ Function to check for new settings and options when the randomizer is updated. """
-    ignore_list = ["tricks_list_msg", "bingosync_url", "dungeon_shortcuts"]
+    ignore_list = ["tricks_list_msg", "bingosync_url", "dungeon_shortcuts", "misc_hints", "mix_entrance_pools", "mq_dungeons_specific", "key_rings"]
 
     # Find new or changed settings by name
     old_settings = list(set(weights.keys()) - set(randomizer_settings.keys()))
@@ -149,6 +151,144 @@ def check_for_setting_changes(weights, randomizer_settings):
         if len(new_options) > 0:
             for name in new_options:
                 print(f"{setting} option {name} is new!")
+
+
+def benchmark_weights(weight_options, weight_dict, weight_multiselect):
+    """ Compare weights file definition to empirical data from generated spoiler logs. """
+    # Initialize weight comparison object
+    settings_counts = {}
+    geometric_multis = []
+    for setting_name, setting_options in weight_dict.items():
+        # custom distros used for woth/goal split, which makes it difficult to directly detect the distro in spoilers
+        if setting_name != 'hint_dist':
+            settings_counts[setting_name] = {"disabled_seeds": 0}
+            option_total = 0
+            for setting_option, option_weight in setting_options.items():
+                settings_counts[setting_name][setting_option] = {
+                    "weight": option_weight,
+                    "total_seeds": 0,
+                    "normalized_weight": 0,
+                    "fraction_seeds": 0
+                }
+                option_total += option_weight
+            # Special case for skull and heart conditionals
+            conditional_mod = 0
+            if "conditionals" in weight_options and setting_name in ['bridge', 'shuffle_ganon_bosskey']:
+                dynamic_options = ["tokens", "hearts"]
+                for dynamic_conditional in ["dynamic_skulltula_wincon", "dynamic_heart_wincon"]:
+                    if dynamic_conditional in weight_options["conditionals"]:
+                        if weight_options["conditionals"][dynamic_conditional][0]:
+                            global_chance = weight_options["conditionals"][dynamic_conditional][1]
+                            split_chance = weight_options["conditionals"][dynamic_conditional][2].split("/")
+                            split_type = ['bridge', 'shuffle_ganon_bosskey'].index(setting_name)
+                            option_name = dynamic_options[["dynamic_skulltula_wincon", "dynamic_heart_wincon"].index(dynamic_conditional)]
+                            option_chance = global_chance/100 * int(split_chance[split_type])/100 + global_chance/100 * int(split_chance[2])/100
+                            settings_counts[setting_name][option_name]["weight"] = "dynamic"
+                            settings_counts[setting_name][option_name]["normalized_weight"] = option_chance
+                            conditional_mod += option_chance
+
+            for setting_option, option_weight in setting_options.items():
+                if settings_counts[setting_name][setting_option]["normalized_weight"] == 0:
+                    settings_counts[setting_name][setting_option]["normalized_weight"] = float(option_weight / option_total * (1 - conditional_mod))
+    for setting_name, multi_options in weight_multiselect.items():
+        settings_counts[setting_name] = {"disabled_seeds": 0}
+        if not multi_options["geometric"]:
+            for setting_option, option_pct in multi_options["opt_percentage"].items():
+                settings_counts[setting_name][setting_option] = {
+                    "weight": str(option_pct) + "% (global " + str(multi_options["global_enable_percentage"]) + "%)",
+                    "total_seeds": 0,
+                    "normalized_weight": float(option_pct / 100 * multi_options["global_enable_percentage"] / 100),
+                    "fraction_seeds": 0
+                }
+        else:
+            geometric_multis.append(setting_name)
+            max_options = len(get_setting_info(setting_name).choices)
+            for option_num in range(0, max_options+1):
+                settings_counts[setting_name][option_num] = {
+                    "weight": str(2**(max_options - option_num)) + " (global " + str(multi_options["global_enable_percentage"]) + "%)",
+                    "total_seeds": 0,
+                    "normalized_weight": float((50.0/2**option_num) / 100 * multi_options["global_enable_percentage"] / 100),
+                    "fraction_seeds": 0
+                }
+
+    # Count instances of each setting option in pre-rolled seeds.
+    # Use the --stress_test option to bulk generate seeds.
+    print("Processing spoilers")
+    fcount = 0
+    ftotal = len(glob.glob(os.path.join("patches", "*_Spoiler.json")))
+    for filename in glob.glob(os.path.join("patches", "*_Spoiler.json")):
+        fcount = fcount + 1
+        afile = filename.split("_")
+        settings_hash = afile[1]
+        seed = afile[2]
+        sys.stdout.write("\r%d / %d: %s   " % (fcount, ftotal, (settings_hash + "_" + seed)))
+        with open(filename) as sp_file:
+            sp = json.load(sp_file)
+            for setting_name, option_value in sp["settings"].items():
+                if isinstance(option_value, list):
+                    setting_option = option_value
+                elif not isinstance(option_value, str):
+                    setting_option = str(option_value)
+                else:
+                    setting_option = option_value
+                if isinstance(option_value, bool):
+                    setting_option = setting_option.lower()
+                if setting_name in settings_counts.keys() and setting_name not in geometric_multis:
+                    if isinstance(setting_option, list):
+                        for o in setting_option:
+                            settings_counts[setting_name][o]["total_seeds"] += 1
+                    else:
+                        settings_counts[setting_name][setting_option]["total_seeds"] += 1
+                if setting_name in settings_counts.keys() and setting_name in geometric_multis:
+                    settings_counts[setting_name][len(setting_option)]["total_seeds"] += 1
+            # If the setting is disabled, it won't be in the spoiler log and skews the seed fraction.
+            for setting_name in settings_counts.keys():
+                if setting_name not in sp["settings"].keys():
+                    settings_counts[setting_name]["disabled_seeds"] += 1
+    for setting_name, setting_options in settings_counts.items():
+        for setting_option, option_data in setting_options.items():
+            if setting_option != 'disabled_seeds':
+                if ftotal != settings_counts[setting_name]["disabled_seeds"]:
+                    settings_counts[setting_name][setting_option]["fraction_seeds"] = float(option_data["total_seeds"] / (ftotal - settings_counts[setting_name]["disabled_seeds"]))
+
+    # Create report
+    print("\nExporting weights report")
+    report = '<!DOCTYPE html><html><head><style>body {font-family: sans-serif;} .setting_container {border-bottom: 1px solid #666; padding: 24px;} .setting_name {font-size: 1.5em; font-weight: bold; margin: 8px 0px} .option_error {background-color: red; color: white;} .option_alert {background-color: yellow;} .setting_disabled {color: #AAA;} .option_row td {padding-right: 16px;} .option_header {font-weight: bold;}</style></head><body><h1>Random Settings Weights Verification</h1>'
+    report += '<div class="option_alert">Yellow options deviate from weights by >10%</div>'
+    report += '<div class="option_error">Red options are not found in any seed despite non-zero weight</div>'
+    report += '<div class="setting_disabled">Grayed-out options are not found in any seeds, likely disabled by another setting</div>'
+    for setting_name, setting_options in settings_counts.items():
+        setting_class = "setting_container"
+        if settings_counts[setting_name]["disabled_seeds"] == ftotal:
+            setting_class += " setting_disabled"
+        report += '<div class="'+setting_class+'"><div class="setting_name">'+setting_name+'</div><table class="setting_options">'
+        report += '<tr class="option_row option_header">' + \
+                  '<td>Option</td>' + \
+                  '<td>Weight</td>' + \
+                  '<td>Total Seeds</td>' + \
+                  '<td>Normalized Weight</td>' + \
+                  '<td>Fraction Seeds</td>' + \
+                  '</tr>'
+        for setting_option, option_data in setting_options.items():
+            if setting_option != 'disabled_seeds':
+                option_class = "option_row"
+                if option_data["total_seeds"] == 0 and option_data["normalized_weight"] != 0 and settings_counts[setting_name]["disabled_seeds"] != ftotal:
+                    option_class += " option_error"
+                if (abs(option_data["fraction_seeds"] - option_data["normalized_weight"]) > option_data["normalized_weight"] / 10 and
+                option_data["normalized_weight"] != 0 and option_data["total_seeds"] != 0):
+                    option_class += " option_alert"
+                report += '<tr class="'+str(option_class)+'">' + \
+                        '<td>'+str(setting_option)+'</td>' + \
+                        '<td>'+str(option_data["weight"])+'</td>' + \
+                        '<td>'+str(option_data["total_seeds"])+'</td>' + \
+                        '<td>'+str(option_data["normalized_weight"])+'</td>' + \
+                        '<td>'+str(option_data["fraction_seeds"])+'</td>' + \
+                        '</tr>'
+        report += '</table></div>'
+    report += "</body></html>"
+    with open("weights_report.html", "w") as report_file:
+        report_file.writelines(report)
+    sys.stdout.write("Report created as %s" % (os.path.abspath("weights_report.html")))
 
 
 class RandomizerError(Exception):

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
-__version__ = "2.2.10"
+__version__ = "2.3.0"
 version_hash_1 = "Map"
 version_hash_2 = "Map"
 
-randomizer_version = '6.2.29 R-1'
-randomizer_commit = 'd30700839d8f03e45516fcae1611e28fd347bdce'
+randomizer_version = '6.2.158 R-1'
+randomizer_commit = 'e6bb67eb389f43b218261fbe5d9e99ccb663a029'

--- a/weights/beginner_override.json
+++ b/weights/beginner_override.json
@@ -17,11 +17,8 @@
         "shuffle_overworld_entrances": {
             "false": 1
         },
-        "mq_dungeons_random": {
-            "false": 1
-        },
-        "mq_dungeons": {
-            "0": 1
+        "mq_dungeons_mode": {
+            "vanilla": 1
         },
         "shuffle_song_items": {
             "song": 6,

--- a/weights/bingo_intermediate_override.json
+++ b/weights/bingo_intermediate_override.json
@@ -12,6 +12,18 @@
         ],
         "allow_random_and_plando": true
     },
+    "multiselect": {
+        "mix_entrance_pools": {
+            "global_enable_percentage": 15,
+            "geometric": false,
+            "opt_percentage": {
+                "Interior": 100,
+                "GrottoGrave": 100,
+                "Dungeon": 100,
+                "Overworld": 0
+            }
+        }
+    },
     "weights": {
         "trials_random": {
             "true": 1
@@ -37,6 +49,7 @@
             "medallions": 3,
             "dungeons": 0,
             "tokens": 0,
+            "hearts": 0,
             "random": 0
         },
         "bridge_medallions": {
@@ -65,11 +78,6 @@
         },
         "shuffle_overworld_entrances": {
             "false": 1
-        },
-        "mix_entrance_pools": {
-            "all": 0,
-            "indoor": 3,
-            "off": 17
         },
         "shuffle_scrubs": {
             "off": 2,
@@ -122,7 +130,8 @@
             "medallions": 0,
             "stones": 0,
             "dungeons": 3,
-            "tokens": 0
+            "tokens": 0,
+            "hearts": 0
         },
         "ganon_bosskey_rewards": {
             "1": 0,
@@ -135,10 +144,10 @@
             "8": 0,
             "9": 0
         },
-        "mq_dungeons_random": {
-            "false": 1
+        "mq_dungeons_mode": {
+            "count": 1
         },
-        "mq_dungeons": {
+        "mq_dungeons_count": {
             "0": 1,
             "1": 1
         },

--- a/weights/bingo_override.json
+++ b/weights/bingo_override.json
@@ -45,7 +45,8 @@
             "medallions": 1,
             "stones": 1,
             "dungeons": 1,
-            "tokens": 0
+            "tokens": 0,
+            "hearts": 0
         },
         "reachable_locations": {
             "all": 1,

--- a/weights/coop_override.json
+++ b/weights/coop_override.json
@@ -3,14 +3,11 @@
         "bridge_tokens_max": 50,
         "ganon_bosskey_tokens_max": 50,
         "triforce_goal_per_world_max": 50,
-        "mq_dungeons": {
-            "0": 1
-        },
         "damage_multiplier": {
             "normal": 1
         },
-        "mq_dungeons_random": {
-            "false": 1
+        "mq_dungeons_mode": {
+            "vanilla": 1
         }
     }
 }

--- a/weights/intermediate_override.json
+++ b/weights/intermediate_override.json
@@ -23,10 +23,10 @@
         "shuffle_overworld_entrances": {
             "false": 1
         },
-        "mq_dungeons_random": {
-            "false": 1
+        "mq_dungeons_mode": {
+            "count": 1
         },
-        "mq_dungeons": {
+        "mq_dungeons_count": {
             "0": 1,
             "1": 1
         },

--- a/weights/rsl_season4.json
+++ b/weights/rsl_season4.json
@@ -2,15 +2,22 @@
     "options": {
         "bridge_tokens_max": 100,
         "ganon_bosskey_tokens_max": 100,
+        "bridge_hearts_min": 4,
+        "ganon_bosskey_hearts_min": 4,
+        "bridge_hearts_max": 20,
+        "ganon_bosskey_hearts_max": 20,
         "triforce_goal_per_world_max": 100,
         "starting_items": true,
         "conditionals": {
-            "exclude_minimal_triforce_hunt": [true],
+            "exclude_minimal_triforce_hunt": [false],
+            "constant_triforce_hunt_extras": [true],
             "exclude_ice_trap_misery": [true],
             "disable_hideoutkeys_independence": [true],
+            "disable_pot_chest_texture_independence": [false],
             "restrict_one_entrance_randomizer": [false],
             "random_scrubs_start_wallet": [true],
             "dynamic_skulltula_wincon": [true, 15, "40/40/20"],
+            "dynamic_heart_wincon": [false, 15, "40/40/20"],
             "shuffle_goal_hints": [true, 50]
         },
         "tricks": [
@@ -29,7 +36,7 @@
             "logic_lens_gtg",
             "logic_lens_shadow",
             "logic_lens_spirit",
-            "logic_visible_collisions", 
+            "logic_visible_collisions",
             "logic_deku_b1_webs_with_bow",
             "logic_lens_gtg_mq",
             "logic_lens_jabu_mq",
@@ -62,6 +69,26 @@
         "dungeon_shortcuts": {
             "global_enable_percentage": 100,
             "geometric": true
+        },
+        "mix_entrance_pools": {
+            "global_enable_percentage": 50,
+            "geometric": false,
+            "opt_percentage": {
+                "Interior": 100,
+                "GrottoGrave": 100,
+                "Dungeon": 100,
+                "Overworld": 20
+            }
+        },
+        "misc_hints": {
+            "global_enable_percentage": 100,
+            "geometric": false,
+            "opt_percentage": {
+                "altar": 100,
+                "ganondorf": 100,
+                "warp_songs": 100,
+                "dampe_diary": 0
+            }
         }
     },
     "weights": {
@@ -101,6 +128,7 @@
             "medallions": 1,
             "dungeons": 1,
             "tokens": 0,
+            "hearts": 0,
             "random": 0
         },
         "bridge_medallions": {
@@ -167,17 +195,18 @@
             "false": 1
         },
         "shuffle_dungeon_entrances": {
-            "true": 1,
-            "false": 1
+            "off": 1,
+            "simple": 1,
+            "all": 0
+        },
+        "shuffle_bosses": {
+            "off": 1,
+            "limited": 0,
+            "full": 0
         },
         "shuffle_overworld_entrances": {
             "true": 2,
             "false": 3
-        },
-        "mix_entrance_pools": {
-            "all": 2,
-            "indoor": 3,
-            "off": 5
         },
         "decouple_entrances": {
             "true": 0,
@@ -195,11 +224,20 @@
             "true": 1,
             "false": 1
         },
-        "mq_dungeons_random": {
-            "true": 1,
-            "false": 4
+        "dungeon_shortcuts_choice": {
+            "off": 0,
+            "choice": 1,
+            "all": 0,
+            "random": 0
         },
-        "mq_dungeons": {
+        "mq_dungeons_mode": {
+            "random": 1,
+            "count": 4,
+            "vanilla": 0,
+            "mq": 0,
+            "specific": 0
+        },
+        "mq_dungeons_count": {
             "0": 4096,
             "1": 2048,
             "2": 1024,
@@ -268,6 +306,10 @@
             "true": 2,
             "false": 3
         },
+        "shuffle_frog_song_rupees": {
+            "true": 0,
+            "false": 1
+        },
         "shuffle_mapcompass": {
             "remove": 1,
             "startwith": 1,
@@ -310,7 +352,8 @@
             "medallions": 1,
             "stones": 1,
             "dungeons": 1,
-            "tokens": 0
+            "tokens": 0,
+            "hearts": 0
         },
         "ganon_bosskey_medallions": {
             "1": 1,
@@ -420,13 +463,20 @@
             "10": 1
         },
         "ocarina_songs": {
-            "true": 0,
-            "false": 1
+            "off": 1,
+            "frog": 0,
+            "warp": 0,
+            "all": 0
         },
         "correct_chest_appearances": {
             "off": 4,
             "textures": 3,
-            "sizes": 3
+            "both": 3,
+            "classic": 0
+        },
+        "invisible_chests": {
+            "true": 0,
+            "false": 1
         },
         "shopsanity_prices": {
             "random": 1,
@@ -439,6 +489,39 @@
         "fast_bunny_hood": {
             "true": 1,
             "false": 0
+        },
+        "blue_fire_arrows": {
+            "true": 0,
+            "false": 1
+        },
+        "easier_fire_arrow_entry": {
+            "true": 0,
+            "false": 1
+        },
+        "fae_torch_count": {
+            "1": 1,
+            "2": 1,
+            "3": 1,
+            "4": 1,
+            "5": 1,
+            "6": 1,
+            "7": 1,
+            "8": 1,
+            "9": 1,
+            "10": 1,
+            "11": 1,
+            "12": 1,
+            "13": 1,
+            "14": 1,
+            "15": 1,
+            "16": 1,
+            "17": 1,
+            "18": 1,
+            "19": 1,
+            "20": 1,
+            "21": 1,
+            "22": 1,
+            "23": 1
         },
         "clearer_hints": {
             "true": 1,
@@ -462,11 +545,10 @@
             "very_strong": 2,
             "mw2": 0,
             "league": 0,
-            "coop2": 0
-        },
-        "misc_hints": {
-            "true": 1,
-            "false": 0
+            "coop2": 0,
+            "chaos": 0,
+            "very_strong_magic": 0,
+            "weekly": 0
         },
         "text_shuffle": {
             "none": 19,
@@ -479,6 +561,14 @@
             "double": 4,
             "quadruple": 2,
             "ohko": 1
+        },
+        "deadly_bonks": {
+            "none": 1,
+            "half": 0,
+            "normal": 0,
+            "double": 0,
+            "quadruple": 0,
+            "ohko": 0
         },
         "no_collectible_hearts": {
             "true": 0,
@@ -500,7 +590,8 @@
             "plentiful": 3,
             "balanced": 9,
             "scarce": 5,
-            "minimal": 3
+            "minimal": 3,
+            "ludicrous": 0
         },
         "junk_ice_traps": {
             "off": 9,

--- a/weights/xopar.json
+++ b/weights/xopar.json
@@ -7,9 +7,9 @@
         "shuffle_overworld_entrances": {
             "false": 1
         },
-        "mq_dungeons_random": {
-            "true": 1,
-            "false": 1
+        "mq_dungeons_mode": {
+            "random": 1,
+            "vanilla": 1
         },
         "useful_cutscenes": {
             "true": 1


### PR DESCRIPTION
Season 4 weights and all overrides are adjusted to work with setting refactors and additions up to randomizer version 6.2.158 R-1. Seasons 2 and 3 weights remain untouched.

Note that Triforce Piece count is no longer tied to the item pool setting. A new conditional maintains a constant 25% extra pieces in the pool.

New command line options are added for testing the script:
* `--stress_test`: Generates the specified number of seeds in bulk. Not recommended with `--no_seed` as there have been problems in the past with the randomizer crashing at patch time with odd settings combinations.
* `--benchmark`: Compiles statistics for each setting in the specified weights + override using previously generated seeds. Generates a webpage with the output color coded for outliers.

Additionally, if the script fails to generate a seed with a given plando, that plando is saved in the `failed_settings` folder for disposition. With S4 weights and roughly 3600 cases, about 60 plandos failed in testing (~1.5%).