### PR TITLE
Add conditional to invert mq count

### DIFF
--- a/conditionals.py
+++ b/conditionals.py
@@ -228,4 +228,4 @@ def invert_dungeons_mq_count(random_settings, weight_dict, **kwargs):
     current_mq_dungeons_count = int(random_settings['mq_dungeons_count'])
     new_mq_dungeons_count = 12 - current_mq_dungeons_count
     
-    random_settings['mq_dungeons_count'] = str(new_mq_dungeons_count)
+    random_settings['mq_dungeons_count'] = new_mq_dungeons_count

--- a/conditionals.py
+++ b/conditionals.py
@@ -211,3 +211,21 @@ def ohko_starts_with_nayrus(random_settings, weight_dict, extra_starting_items, 
     """ If one hit ko is enabled, add Nayru's Love to the starting items """
     if random_settings['damage_multiplier'] == 'ohko':
         extra_starting_items['starting_items'] += ['nayrus_love']
+
+def invert_dungeons_mq_count(random_settings, weight_dict, **kwargs):
+    """ When activated will invert the MQ dungeons count
+        kwargs: [chance of having the MQ count reversed]
+    """
+    if random_settings['mq_dungeons_mode'] != 'count':
+        return
+
+    chance_of_inverting_mq_count = int(kwargs['cparams'][0])
+    invert_mq_count = random.choices([True, False], weights=[chance_of_inverting_mq_count, 100-chance_of_inverting_mq_count])[0]
+
+    if not invert_mq_count:
+        return
+    
+    current_mq_dungeons_count = int(random_settings['mq_dungeons_count'])
+    new_mq_dungeons_count = 12 - current_mq_dungeons_count
+    
+    random_settings['mq_dungeons_count'] = str(new_mq_dungeons_count)

--- a/conditionals.py
+++ b/conditionals.py
@@ -214,7 +214,7 @@ def ohko_starts_with_nayrus(random_settings, weight_dict, extra_starting_items, 
 
 def invert_dungeons_mq_count(random_settings, weight_dict, **kwargs):
     """ When activated will invert the MQ dungeons count
-        kwargs: [chance of having the MQ count reversed]
+        kwargs: [chance of having the MQ count inverted]
     """
     if random_settings['mq_dungeons_mode'] != 'count':
         return

--- a/weights/rsl_season5.json
+++ b/weights/rsl_season5.json
@@ -23,7 +23,8 @@
             "replace_dampe_diary_hint_with_lightarrow": [true],
             "adjust_chaos_hint_distro": [true],
             "exclude_mapcompass_info_remove": [true],
-            "ohko_starts_with_nayrus": [true]
+            "ohko_starts_with_nayrus": [true],
+            "invert_dungeons_mq_count": [false, 0]
         },
         "tricks": [
             "logic_fewer_tunic_requirements",


### PR DESCRIPTION
So here is what I was thinking

All of the following is only when the MQ dungeon mode is set to "count"

This is how I describe my current understanding of the MQ weight distribution:
> All dungeons are NonMQ except a random count of MQ dungeons

The idea of this conditional is to have the reverse rule: 
> All dungeons are MQ except a random count of NonMQ dungeons

Example :
```
MQ Dungeon mode is : "count"
Setting roll gives you : 4 MQ

Conditional is activated
Seed will have : 8MQ
``` 

Of course I'm not a monster :smiling_imp: the conditional take a percentage of chance as an input so it will not be activated on every seed you're rolling.