### PR TITLE
Make more variants of the decompressor executable

### DIFF
--- a/update_randomizer.py
+++ b/update_randomizer.py
@@ -54,7 +54,14 @@ def download_randomizer():
         pass
 
     # Restore permissions in the unzipped randomizer
-    for executable in [os.path.join('randomizer', 'OoTRandomizer.py'), os.path.join('randomizer', 'bin', 'Decompress', 'Decompress'), os.path.join('randomizer', 'bin', 'Decompress', 'Decompress.out')]:
+    for executable in [
+        os.path.join('randomizer', 'OoTRandomizer.py'),
+        os.path.join('randomizer', 'bin', 'Decompress', 'Decompress'),
+        os.path.join('randomizer', 'bin', 'Decompress', 'Decompress_ARM32'),
+        os.path.join('randomizer', 'bin', 'Decompress', 'Decompress_ARM64'),
+        os.path.join('randomizer', 'bin', 'Decompress', 'Decompress.out'),
+        os.path.join('randomizer', 'bin', 'Decompress', 'Decompress_ARM64.out'),
+    ]:
         os.chmod(executable, os.stat(executable).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     # Delete the zip file


### PR DESCRIPTION
This adds:

* `Decompress_ARM32` (Linux on 32-bit ARM)
* `Decompress_ARM64` (Linux on 64-bit ARM)
* `Decompress_ARM64.out` (macOS on 64-bit ARM aka Apple Silicon)