### PR TITLE
Add CLI option to customize the plando filename prefix

### DIFF
--- a/RandomSettingsGenerator.py
+++ b/RandomSettingsGenerator.py
@@ -69,6 +69,8 @@ def get_command_line_args():
                         help="When the version updates, run with this flag to find changes to settings names or new settings.")
     parser.add_argument("--no_log_errors", action="store_true", default=False,
                         help="Only show errors in the console, don't log them to a file.")
+    parser.add_argument("--plando_filename_base", default="random_settings",
+                        help="First part of the file names for the generated plandomizer files.")
     parser.add_argument("--stress_test", type=range_limited_int_type, default=1, dest="seed_count",
                         help="Generate the specified number of seeds for benchmarking.")
     parser.add_argument("--benchmark", action="store_true",
@@ -97,6 +99,7 @@ def get_command_line_args():
         "worldcount": args.worldcount,
         "override_fname": args.override or global_override_fname,
         "check_new_settings": args.check_new_settings,
+        "plando_filename_base": args.plando_filename_base,
         "seed_count": args.seed_count,
         "benchmark": args.benchmark,
         "plando_retries": args.plando_retries,
@@ -130,7 +133,7 @@ def main():
 
         plandos_to_cleanup = []
         for i in range(args["plando_retries"]):
-            plando_filename = rs.generate_plando(WEIGHTS, args["override_fname"], args["no_seed"])
+            plando_filename = rs.generate_plando(WEIGHTS, args["override_fname"], args["no_seed"], args["plando_filename_base"])
             if args["no_seed"]:
                 break
             plandos_to_cleanup.append(plando_filename)

--- a/roll_settings.py
+++ b/roll_settings.py
@@ -187,7 +187,7 @@ def generate_weights_override(weights, override_weights_fname):
     return weight_options, weight_multiselect, weight_dict, start_with
 
 
-def generate_plando(weights, override_weights_fname, no_seed):
+def generate_plando(weights, override_weights_fname, no_seed, plando_filename_base='random_settings'):
     weight_options, weight_multiselects, weight_dict, start_with = generate_weights_override(weights, override_weights_fname)
 
     ####################################################################################
@@ -255,7 +255,7 @@ def generate_plando(weights, override_weights_fname, no_seed):
     # Save the output plando
     output = {"settings": random_settings}
 
-    plando_filename = f'random_settings_{datetime.datetime.utcnow():%Y-%m-%d_%H-%M-%S_%f}.json'
+    plando_filename = f'{plando_filename_base}_{datetime.datetime.utcnow():%Y-%m-%d_%H-%M-%S_%f}.json'
     # plando_filename = f'random_settings.json'
 
     if not os.path.isdir("data"):


### PR DESCRIPTION
[ootrstats](https://github.com/fenhl/ootrstats) invokes the RSL script multiple times in parallel, which leads to crashes due to conflicting filenames when two instances happen to create their plandos in the same microsecond (which happens more often than you might think). With this option, ootrstats can invoke each instance of the RSL script with a different filename prefix, avoiding this collision.