### PR TITLE
Allow specifying override on stdin

### DIFF
--- a/RandomSettingsGenerator.py
+++ b/RandomSettingsGenerator.py
@@ -84,9 +84,10 @@ def get_command_line_args():
     if args.override is not None:
         if global_override_fname is not None:
             raise RuntimeError("RSL GENERATOR ERROR: PROVIDING MULTIPLE SETTINGS WEIGHT OVERRIDES IS NOT SUPPORTED.")
-        override_path = os.path.join(os.getcwd(), args.override)
-        if not os.path.isfile(override_path):
-            raise FileNotFoundError(f"RSL GENERATOR ERROR: CANNOT FIND SPECIFIED OVERRIDE FILE IN DIRECTORY:\n{override_path}")
+        if args.override != '-':
+            override_path = os.path.join(os.getcwd(), args.override)
+            if not os.path.isfile(override_path):
+                raise FileNotFoundError(f"RSL GENERATOR ERROR: CANNOT FIND SPECIFIED OVERRIDE FILE IN DIRECTORY:\n{override_path}")
 
     # Parse args
     LOG_ERRORS = not args.no_log_errors

--- a/roll_settings.py
+++ b/roll_settings.py
@@ -23,7 +23,10 @@ def load_weights_file(weights_fname):
     if os.path.isfile(fpath):
         with open(fpath) as fin:
             datain = json.load(fin)
+    return parse_weights(datain)
 
+
+def parse_weights(datain):
     weight_options = datain["options"] if "options" in datain else None
     conditionals = datain["conditionals"] if "conditionals" in datain else None
     weight_multiselect = datain["multiselect"] if "multiselect" in datain else None
@@ -140,8 +143,12 @@ def generate_weights_override(weights, override_weights_fname):
     # If an override_weights file name is provided, load it
     start_with = {"starting_inventory":[], "starting_songs":[], "starting_equipment":[]}
     if override_weights_fname is not None:
-        print(f"RSL GENERATOR: LOADING OVERRIDE WEIGHTS from {override_weights_fname}")
-        override_options, override_conditionals, override_multiselect, override_weights = load_weights_file(override_weights_fname)
+        if override_weights_fname == '-':
+            print("RSL GENERATOR: LOADING OVERRIDE WEIGHTS from standard input")
+            override_options, override_conditionals, override_multiselect, override_weights = parse_weights(json.load(sys.stdin))
+        else:
+            print(f"RSL GENERATOR: LOADING OVERRIDE WEIGHTS from {override_weights_fname}")
+            override_options, override_conditionals, override_multiselect, override_weights = load_weights_file(override_weights_fname)
         # Check for starting items, songs and equipment
         for key in start_with.keys():
             if key in override_weights.keys():


### PR DESCRIPTION
This adds a special case to the `--override` CLI option to treat `-` as “standard input”, like many command-line tools do. This allows passing custom overrides to the random settings generator without having to save them on disk first, which is useful for dynamically generated weights, e.g. from a settings draft managed by Mido.