### PR TITLE
Allow specifying seed

### DIFF
--- a/RandomSettingsGenerator.py
+++ b/RandomSettingsGenerator.py
@@ -3,6 +3,8 @@ import sys
 import os
 import traceback
 import argparse
+import random
+import hashlib
 
 import update_randomizer as ur
 ur.check_python()
@@ -11,6 +13,7 @@ ur.check_version()
 from utils import cleanup
 import rsl_tools as tools
 import roll_settings as rs
+from rslversion import __version__
 
 global_override_fname = None
 
@@ -79,6 +82,7 @@ def get_command_line_args():
                         help="Retry limit for generating a plando file.")
     parser.add_argument("--rando_retries", type=range_limited_int_type, default=3,
                         help="Retry limit for running the randomizer with a given settings plando.")
+    parser.add_argument("--seed", help="Generate the specified seed.")
     args = parser.parse_args()
 
 
@@ -93,6 +97,10 @@ def get_command_line_args():
 
     # Parse args
     LOG_ERRORS = not args.no_log_errors
+
+    if args.seed is not None:
+        full_string = __version__ + args.seed
+        random.seed(int(hashlib.sha256(full_string.encode('utf-8')).hexdigest(), 16))
 
     # Condense everything into a dict
     return {

--- a/RandomSettingsGenerator.py
+++ b/RandomSettingsGenerator.py
@@ -3,6 +3,8 @@ import sys
 import os
 import traceback
 import argparse
+import random
+import hashlib
 
 import update_randomizer as ur
 ur.check_python()
@@ -12,6 +14,7 @@ from utils import cleanup
 import rsl_tools as tools
 import roll_settings as rs
 import validation
+from rslversion import __version__
 
 global_override_fname = None
 
@@ -82,6 +85,7 @@ def get_command_line_args():
                         help="Retry limit for generating a plando file.")
     parser.add_argument("--rando_retries", type=range_limited_int_type, default=3,
                         help="Retry limit for running the randomizer with a given settings plando.")
+    parser.add_argument("--seed", help="Generate the specified seed.")
     args = parser.parse_args()
 
 
@@ -96,6 +100,10 @@ def get_command_line_args():
 
     # Parse args
     LOG_ERRORS = not args.no_log_errors
+
+    if args.seed is not None:
+        full_string = __version__ + args.seed
+        random.seed(int(hashlib.sha256(full_string.encode('utf-8')).hexdigest(), 16))
 
     # Condense everything into a dict
     return {

--- a/rsl_tools.py
+++ b/rsl_tools.py
@@ -5,6 +5,7 @@ import subprocess
 import os
 import json
 import glob
+import random
 sys.path.append("randomizer")
 # from randomizer.SettingsList import get_setting_info
 from randomizer.SettingsList import SettingInfos
@@ -32,7 +33,7 @@ def init_randomizer_settings(plando_filename='random_settings.json', worldcount=
         json.dump(settings, fout, indent=4)
 
 
-def generate_patch_file(plando_filename='random_settings.json', worldcount=1, max_retries=3):
+def generate_patch_file(plando_filename='random_settings.json', worldcount=1, max_retries=3, seed=None):
     """ Using the randomized settings, roll a seed using the randomizer CLI. """
     settings = json.dumps(randomizer_settings_func(plando_filename=plando_filename, worldcount=worldcount))
 
@@ -40,7 +41,7 @@ def generate_patch_file(plando_filename='random_settings.json', worldcount=1, ma
     while True:
         print(f"RSL GENERATOR: RUNNING THE RANDOMIZER - ATTEMPT {retries+1} OF {max_retries}")
         completed_process = subprocess.run(
-            [sys.executable, os.path.join("randomizer", "OoTRandomizer.py"), "--settings=-"],
+            [sys.executable, os.path.join("randomizer", "OoTRandomizer.py"), "--settings=-", f"--seed={int(random.getrandbits(256))}"],
             capture_output=True,
             input=settings,
             encoding='utf-8',


### PR DESCRIPTION
Adds a `--seed` CLI option which is used to set [`random.seed`](https://docs.python.org/3.9/library/random.html#random.seed) for the RSL script. Additionally, the randomizer seed is now generated by the RSL script rather than the randomizer itself. Together, these two changes should make the RSL script completely deterministic when a seed is specified. This is useful for stats and for debugging the script.