### PR TITLE
Only import requests if necessary

### DIFF
--- a/update_randomizer.py
+++ b/update_randomizer.py
@@ -6,11 +6,6 @@ import shutil
 import subprocess
 from utils import cleanup
 import rslversion as rslv
-try:
-    import requests
-except ModuleNotFoundError:
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'requests'])
-    import requests
 
 
 def check_python():
@@ -35,6 +30,13 @@ def check_version():
 
 def download_randomizer():
     """ Download the randomizer from commit listed in version.py """
+
+    try:
+        import requests
+    except ModuleNotFoundError:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'requests'])
+        import requests
+
     zippath = 'randomizer.zip'
 
     # Make sure an old zip isn't sitting around


### PR DESCRIPTION
This moves the `requests` import and associated `pip` call into the function that updates the randomizer, allowing it to be skipped if it's never called because the randomizer is up to date.

Not only does this save a small amount of runtime on subsequent runs of the RSL script, it's also one more thing that simplifies running multiple instances of the script in parallel: [ootrstats](https://github.com/fenhl/ootrstats) now downloads the randomizer before running the RSL script, which combined with this PR avoids `pip` misbehaving due to running multiple times in parallel.